### PR TITLE
More lock file fixes

### DIFF
--- a/abs
+++ b/abs
@@ -25,7 +25,7 @@
 declare -r backupNameDefault="daily"
 declare -r backupCfg="/usr/local/etc/abs/abs.conf"
 declare -r excludeCfg="/usr/local/etc/abs/exclude.conf"
-declare -r lockFile="/var/run/backups.pid"
+declare -r lockFile="/var/run/abs.pid"
 declare -r bwLimit="0"
 declare -r ionice_cmd="ionice -c 2 -n 6"
 

--- a/arms
+++ b/arms
@@ -26,7 +26,7 @@ declare -r ionice_cmd="ionice -c 2 -n 7"
 declare -r hostName="${1}"
 declare -r srcPath="${2}"
 declare -r dstPath="${3}"
-declare -r lockFile="/var/run/backups.pid"
+declare -r lockFile="/var/run/arms.pid"
 declare -r bwLimit="0"
 
 # There should be no reason to touch anything below this line.

--- a/arms
+++ b/arms
@@ -68,8 +68,7 @@ function printError()
     echo "Error: ${@}" 1>&2
 }
 
-# If a lock file exists, wait until it is removed.
-function waitIfLocked()
+function setLockFile()
 {
     declare cmdAtPID
 
@@ -84,12 +83,19 @@ function waitIfLocked()
             # Wait 10 minutes and try again.
             echo "Sleeping, waiting for the lock to free up."
             sleep 600
-            waitIfLocked
+            setLockFile
         else
-            # Old lock file. Nuke it.
-            rm -f "${lockFile}"
+            # Old lock file. Overwrite it.
+            echo ${$} > "${lockFile}"
         fi
+    else
+        echo ${$} > "${lockFile}"
     fi
+}
+
+function delLockFile()
+{
+    rm -f "${lockFile}"
 }
 
 function rsyncCmd()
@@ -134,7 +140,8 @@ function rsyncCmd()
 #
 
 doSafetyChecks
-waitIfLocked
+setLockFile
 rsyncCmd
+delLockFile
 
 # EOF


### PR DESCRIPTION
I discovered arms wasn't writing lock files - only deleting them if they existed. This seems to be the reason why I was still seeing many rsync processes on the backup server for both abs and arms, causing huge slowdowns.
