### PR TITLE
Reinstate eval where cmdWrap is used

### DIFF
--- a/abs
+++ b/abs
@@ -262,8 +262,6 @@ function rsyncCmd()
     touch "${local_backup_dir}.0.incomplete"
     last_good="$(findLastGoodBackup "${local_path}" "${backup_name}")"
 
-    # We use eval so the bash (semi-)builtin command takes precedence
-    # when the time package/comamnd is installed.
     eval ${cmdWrap} rsync -a -e \'ssh -q\' --delete \
         $([ -n "${bwLimit}" ] && echo --bwlimit=${bwLimit}) \
         $([ "${rmtPathName}" = "/" ] && echo ${rsyncExclude}) \
@@ -373,7 +371,8 @@ function syncFiles()
         eval ${cmdWrap} cp -al \
             "${local_path}/${backupNameDefault}.${last_good}" \
             "${local_path}/${backup_name}.0" && \
-            ${cmdWrap} rm -f "${local_path}/${backup_name}.0.incomplete" || \
+            eval ${cmdWrap} rm -f \
+                "${local_path}/${backup_name}.0.incomplete" || \
             printWarning \
                 "Problem detected creating backup '${backup_name}.0'."
 

--- a/arms
+++ b/arms
@@ -117,8 +117,6 @@ function rsyncCmd()
 
     [ "${verbose}" -ne 0 ] && cmdWrap="time ${cmdWrap}"
 
-    # We use eval so the bash (semi-)builtin command takes precedence
-    # when the time package/comamnd is installed.
     eval ${cmdWrap} rsync -aH -e \'ssh -q\' --delete \
         $([ -n "${bwLimit}" ] && echo --bwlimit=${bwLimit}) \
         ${srcPath} root@${hostName}:${dstPath} || rsyncFail=1


### PR DESCRIPTION
The issue was debugged and this fix was rolled out last week. No problems observed so far.

There will be one more PR later this week which is just a bunch of formatting improvements, but I'm just rolling out and testing one change at a time, and am only creating a PR once I'm confident.